### PR TITLE
Remove string from copyText state

### DIFF
--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -15,7 +15,7 @@ export const CodeBlock: FC<Props> = ({
   editable = false,
   onChange = () => {},
 }) => {
-  const [copyText, setCopyText] = useState<string>('Copy');
+  const [copyText, setCopyText] = useState('Copy');
 
   useEffect(() => {
     const timeout = setTimeout(() => {


### PR DESCRIPTION
In TypeScript, it is not mandatory to set types for all generics.

Though, `useState` is a generic function that takes a type argument to specify the type of the state variable. 

In this case, it's possible to remove the type annotation from the `useState` call because TypeScript can **infer the type** of the state variable based on the **initial value**. In this case, since the initial value is a **string literal** ('Copy'), TypeScript will infer that the type of the copyText state variable is a string.