### PR TITLE
Add OPENAI_API_HOST const to support Local APIs

### DIFF
--- a/utils/const.ts
+++ b/utils/const.ts
@@ -1,0 +1,2 @@
+export const OPENAI_API_HOST =
+  process.env.OPENAI_API_HOST || 'https://api.openai.com';

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -4,6 +4,7 @@ import {
   ParsedEvent,
   ReconnectInterval,
 } from 'eventsource-parser';
+import { OPENAI_API_HOST } from './const';
 
 const createPrompt = (
   inputLanguage: string,
@@ -82,7 +83,7 @@ export const OpenAIStream = async (
 
   const system = { role: 'system', content: prompt };
 
-  const res = await fetch(`https://api.openai.com/v1/chat/completions`, {
+  const res = await fetch(`${OPENAI_API_HOST}/v1/chat/completions`, {
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${key || process.env.OPENAI_API_KEY}`,


### PR DESCRIPTION
Adopting similar approach to what is already in chatbot-ui (see https://github.com/mckaywrigley/chatbot-ui/pull/152/files). 

This gives a lot of flexibility and allows for out-of-the-box compatibility for llama-based API wrappers like https://github.com/keldenl/gpt-llama.cpp!