### PR TITLE
Added support for "gpt-3.5-turbo-16K"

### DIFF
--- a/components/ModelSelect.tsx
+++ b/components/ModelSelect.tsx
@@ -18,6 +18,7 @@ export const ModelSelect: FC<Props> = ({ model, onChange }) => {
       onChange={handleChange}
     >
       <option value="gpt-3.5-turbo">GPT-3.5</option>
+      <option value="gpt-3.5-turbo-16k">GPT-3.5 Turbo 16k</option>
       <option value="gpt-4">GPT-4</option>
     </select>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -18,7 +18,15 @@ export default function Home() {
   const [apiKey, setApiKey] = useState<string>('');
 
   const handleTranslate = async () => {
-    const maxCodeLength = model === 'gpt-3.5-turbo' ? 6000 : 12000;
+    let maxCodeLength;
+
+    if (model === 'gpt-3.5-turbo') {
+      maxCodeLength = 6000;
+    } else if (model === 'gpt-3.5-turbo-16k') {
+      maxCodeLength = 24000;
+    } else {
+      maxCodeLength = 12000;
+    }
 
     if (!apiKey) {
       alert('Please enter an API key.');

--- a/types/types.ts
+++ b/types/types.ts
@@ -1,4 +1,4 @@
-export type OpenAIModel = 'gpt-3.5-turbo' | 'gpt-4';
+export type OpenAIModel = 'gpt-3.5-turbo' | 'gpt-3.5-turbo-16k' | 'gpt-4';
 
 export interface TranslateBody {
   inputLanguage: string;


### PR DESCRIPTION
This pull request solves #40 and introduces support for the new GPT-3.5 Turbo 16k model, which has a higher character limit of 24,000. The existing codebase is updated to handle this new model and adjust the maximum character length accordingly. This enhancement ensures that users can take full advantage of the extended capacity of the GPT-3.5 Turbo 16k model for larger input code snippets.

Changes Made:
Added support for the "gpt-3.5-turbo-16k" model in the ModelSelect component.
Modified the handleTranslate function to set the character limit to 24,000 when using the "gpt-3.5-turbo-16k" model.
Updated the input validation to check the maximum code length based on the selected model.

Testing:
Tested the ModelSelect component with the new "gpt-3.5-turbo-16k" option to ensure proper selection and handling of the model.
Verified that the handleTranslate function correctly enforces the character limit of 24,000 for the "gpt-3.5-turbo-16k" model and retains the previous limits for other models.
Ensured that the application behaves as expected when translating code snippets with the "gpt-3.5-turbo-16k" model, and the output is displayed accurately.